### PR TITLE
Layer-architecture introduced.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM jupyter/scipy-notebook
-
-WORKDIR /home/jovyan/work
-
-# Install project-specific requirements.
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
 .SILENT: install
 
+JUDO_BIN="/usr/local/bin/judo"
+JUDO_DATA_DIR="/usr/local/share/judo"
+
 install:
-	cp judo /usr/local/bin/judo
-	chmod 605 /usr/local/bin/judo
-	mkdir /usr/local/share/judo
-	chmod 755 /usr/local/share/judo
-	cp Dockerfile /usr/local/share/judo/Dockerfile
-	chmod 604 /usr/local/share/judo/Dockerfile
+	cp src/judo $(JUDO_BIN)
+	mkdir $(JUDO_DATA_DIR)
+	cp src/Dockerfile src/plugin-install.sh src/setup-config.sh $(JUDO_DATA_DIR)
+	chmod 755 $(JUDO_BIN)
+	chmod 777 $(JUDO_DATA_DIR)
+	chmod 744 $(JUDO_DATA_DIR)/Dockerfile
+	chmod 755 $(JUDO_DATA_DIR)/plugin-install.sh $(JUDO_DATA_DIR)/setup-config.sh
 
 uninstall:
-	rm -r /usr/local/bin/judo
-	rm -r /usr/local/share/judo
+	rm $(JUDO_BIN)
+	rm -r $(JUDO_DATA_DIR)

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,0 +1,26 @@
+# Install IDE
+ARG BASE_IMAGE="jupyter/scipy-notebook"
+FROM ${BASE_IMAGE}
+
+ENV WORKDIR="/home/jovyan/work"
+WORKDIR ${WORKDIR}
+
+USER root
+
+# Install developer plugins
+COPY ./plugin-install.sh /usr/local/share/judo/
+COPY ./setup-config.sh /usr/local/share/judo/
+COPY ./developer-plugins/ /tmp/developer-plugins/
+
+# Setup developer configuration
+COPY ./developer-config.sh /tmp/developer-config.sh
+
+# Install project plugins
+COPY ./plugins/ /tmp/project-plugins/
+
+# Setup project configuration
+COPY ./config.sh /tmp/project-config.sh
+
+RUN . /usr/local/share/judo/plugin-install.sh && . /usr/local/share/judo/setup-config.sh
+
+# USER jovyan

--- a/src/judo
+++ b/src/judo
@@ -43,23 +43,34 @@ done
 
 case $command in
     init)
-        cp $data_root"/Dockerfile" .
+        mkdir -p .judo/plugins
+        touch .judo/config.sh
+        datafiles=$(ls -d "$data_root"/*)
+        datafile_names=$(ls $data_root)
+        cp -r --preserve=all $HOME/.config/judo/plugins .judo/developer-plugins
+        cp $HOME/.config/judo/config.sh .judo/developer-config.sh
+        echo $datafiles | sed 's/ /\n/g' | xargs -I{} cp -r --preserve=all {} .judo
         touch requirements.txt && chmod 604 requirements.txt
         if [ ! -d ".git" ]; then
             git init
             # Get up-to-date gitignore file for a jupyter notebook.
             git fetch --depth=1 git@github.com:jupyter/notebook.git
             git checkout FETCH_HEAD -- .gitignore
-            git add Dockerfile requirements.txt
+            git add requirements.txt
         fi
         # Use alternative image if specified.
-        [ ! -z $image ] && sed -i "s/FROM .*/FROM $image/" Dockerfile
-        docker build -t $project_name .
-        rm Dockerfile
+        if [ ! -z $image ]; then
+            alternative_image="--build-arg BASE_IMAGE=$image"
+        fi
+        docker build -t $project_name $alternative_image .judo
+        cd .judo
+        rm -r developer-plugins
+        rm developer-config.sh
+        echo $datafile_names | sed 's/ /\n/g' | xargs rm -r
         ;;
 
     run)
-        docker run --pull never -it --rm -p $port:8888 -v $PWD:/home/jovyan/work --name $project_name $project_name
+        docker run --pull never -e GRANT_SUDO=yes --user=root -it --rm -p $port:8888 -v $PWD:/home/jovyan/work --name $project_name $project_name
         ;;
 
     help|*)

--- a/src/plugin-install.sh
+++ b/src/plugin-install.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+DEVELOPER_PLUGINS_DIR='/tmp/developer-plugins'
+PROJECT_PLUGINS_DIR='/tmp/project-plugins'
+
+if [ $(\ls -A $PROJECT_PLUGINS_DIR | head -1) ]; then
+    LOAD_PLUGINS=$PROJECT_PLUGINS_DIR
+elif [ $(\ls -A $DEVELOPER_PLUGINS_DIR | head -1) ]; then
+    LOAD_PLUGINS=$DEVELOPER_PLUGINS_DIR
+fi
+
+if [ ! -z $LOAD_PLUGINS ]; then
+    for plugin in $(ls -d "$LOAD_PLUGINS"/* | sed 's/ /\n/g'); do
+        echo $plugin
+        cd $plugin
+        sh run.sh
+    done
+fi

--- a/src/setup-config.sh
+++ b/src/setup-config.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+sh /tmp/developer-config.sh
+sh /tmp/project-config.sh


### PR DESCRIPTION
This pull request introduces a layering-structure which enables judo to load plugins.
The layering-structure distinguishes between a developer-configuration and a project-configuration.
While the Dockerimage contains the IDE (Jupyter Notebook), each developer may have certain preferences on the look-and-feel of his projects, packages to use (torch in my case) or linux programs to use (vim in my case). Thus, in ~/.config/judo, the respective settings can be set.
The settings are overriden by project-specific settings, set in <project-directory>/.judo/config.sh